### PR TITLE
fix: check for flash availability only on current camera, not all cameras

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ jks/
 /build/
 build/
 example/build
+example/.flutter-plugins-dependencies
 
 # Android related
 **/android/**/gradle-wrapper.jar

--- a/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -1111,4 +1111,12 @@ public class Camera {
             : (isFrontFacing) ? -currentOrientation : currentOrientation;
     return (sensorOrientationOffset + sensorOrientation + 360) % 360;
   }
+
+  public boolean hasFlash() {
+    final Boolean hasFlash = mCameraCharacteristics.get(CameraCharacteristics.FLASH_INFO_AVAILABLE);
+    if(hasFlash != null) {
+      return hasFlash;
+    }
+    return false;
+  }
 }

--- a/android/src/main/java/io/flutter/plugins/camera/MethodCallHandlerImpl.java
+++ b/android/src/main/java/io/flutter/plugins/camera/MethodCallHandlerImpl.java
@@ -173,7 +173,11 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
       }
       case "hasFlash":
       {
-        result.success(hasFlash());
+        if(camera != null) {
+          result.success(camera.hasFlash());
+        } else {
+          result.success(false);
+        }
         break;
       }
 
@@ -196,12 +200,6 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
     methodChannel.setMethodCallHandler(null);
   }
 
-  private boolean hasFlash() {
-    return activity
-            .getApplicationContext()
-            .getPackageManager()
-            .hasSystemFeature(PackageManager.FEATURE_CAMERA_FLASH);
-  }
   private void instantiateCamera(MethodCall call, Result result) throws CameraAccessException {
     String cameraName = call.argument("cameraName");
     String resolutionPreset = call.argument("resolutionPreset");

--- a/example/.flutter-plugins-dependencies
+++ b/example/.flutter-plugins-dependencies
@@ -1,1 +1,0 @@
-{"_info":"// This is a generated file; do not edit or check into version control.","dependencyGraph":[{"name":"camera","dependencies":[]},{"name":"e2e","dependencies":[]},{"name":"path_provider","dependencies":[]},{"name":"video_player","dependencies":["video_player_web"]},{"name":"video_player_web","dependencies":[]}]}

--- a/ios/Classes/CameraPlugin.m
+++ b/ios/Classes/CameraPlugin.m
@@ -698,8 +698,7 @@ FourCharCode const videoFormat = kCVPixelFormatType_32BGRA;
   }
 }
 - (bool)hasFlash {
-  AVCaptureDevice *device = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
-  return ([device hasFlash] && [device hasFlash]);
+  return [_captureDevice hasFlash];
 }
 - (void)setFlashMode:(int)flashMode {
   [self setFlashMode:flashMode level:1.0];


### PR DESCRIPTION
Without this fix you cannot be sure if your current camera has flash, or if it's just flash on another camera. On iOS the entire app willl crash if you try to take a photo with flash on a camera that doesn't have flash, with this fix you can actually check the flash availability correctly.