### PR TITLE
Rename the plugin to remain compatible with other libraries which use the official Camera plugin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ Add flash, auto exposure, zoom and auto focus support for IOS and Android
 ## 0.5.1
 
 * Can now be compiled with earlier Android sdks below 21 when
-`<uses-sdk tools:overrideLibrary="io.flutter.plugins.camera"/>` has been added to the project
+`<uses-sdk tools:overrideLibrary="com.tudutu.plugins.flutterBetterCamera"/>` has been added to the project
 `AndroidManifest.xml`. For sdks below 21, the plugin won't be registered and calls to it will throw
 a `MissingPluginException.`
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
-group 'com.tudutu.plugins.flutterBetterCamera'
+group 'com.tudutu.plugins.flutterbettercamera'
 version '1.0-SNAPSHOT'
 
 buildscript {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
-group 'io.flutter.plugins.camera'
+group 'com.tudutu.plugins.flutterBetterCamera'
 version '1.0-SNAPSHOT'
 
 buildscript {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="io.flutter.plugins.camera">
+  package="com.tudutu.plugins.flutterBetterCamera">
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
 </manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.tudutu.plugins.flutterBetterCamera">
+  package="com.tudutu.plugins.flutterbettercamera">
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
 </manifest>

--- a/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/Camera.java
+++ b/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/Camera.java
@@ -1,7 +1,7 @@
-package com.tudutu.plugins.flutterBetterCamera;
+package com.tudutu.plugins.flutterbettercamera;
 
 import static android.view.OrientationEventListener.ORIENTATION_UNKNOWN;
-import static com.tudutu.plugins.flutterBetterCamera.CameraUtils.computeBestPreviewSize;
+import static com.tudutu.plugins.flutterbettercamera.CameraUtils.computeBestPreviewSize;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;

--- a/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/Camera.java
+++ b/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/Camera.java
@@ -1,7 +1,7 @@
-package io.flutter.plugins.camera;
+package com.tudutu.plugins.flutterBetterCamera;
 
 import static android.view.OrientationEventListener.ORIENTATION_UNKNOWN;
-import static io.flutter.plugins.camera.CameraUtils.computeBestPreviewSize;
+import static com.tudutu.plugins.flutterBetterCamera.CameraUtils.computeBestPreviewSize;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;

--- a/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/CameraPermissions.java
+++ b/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/CameraPermissions.java
@@ -1,4 +1,4 @@
-package com.tudutu.plugins.flutterBetterCamera;
+package com.tudutu.plugins.flutterbettercamera;
 
 import android.Manifest;
 import android.Manifest.permission;

--- a/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/CameraPermissions.java
+++ b/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/CameraPermissions.java
@@ -1,4 +1,4 @@
-package io.flutter.plugins.camera;
+package com.tudutu.plugins.flutterBetterCamera;
 
 import android.Manifest;
 import android.Manifest.permission;

--- a/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/CameraPlugin.java
+++ b/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/CameraPlugin.java
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-package com.tudutu.plugins.flutterBetterCamera;
+package com.tudutu.plugins.flutterbettercamera;
 
 import android.app.Activity;
 import android.os.Build;
@@ -13,14 +13,14 @@ import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
-import com.tudutu.plugins.flutterBetterCamera.CameraPermissions.PermissionsRegistry;
+import com.tudutu.plugins.flutterbettercamera.CameraPermissions.PermissionsRegistry;
 import io.flutter.view.TextureRegistry;
 
 /**
  * Platform implementation of the camera_plugin.
  *
  * <p>Instantiate this in an add to app scenario to gracefully handle activity and context changes.
- * See {@code com.tudutu.plugins.flutterBetterCamera.MainActivity} for an example.
+ * See {@code com.tudutu.plugins.flutterbettercamera.MainActivity} for an example.
  *
  * <p>Call {@link #registerWith(Registrar)} to register an implementation of this that uses the
  * stable {@code io.flutter.plugin.common} package.
@@ -34,7 +34,7 @@ public final class CameraPlugin implements FlutterPlugin, ActivityAware {
   /**
    * Initialize this within the {@code #configureFlutterEngine} of a Flutter activity or fragment.
    *
-   * <p>See {@code com.tudutu.plugins.flutterBetterCamera.MainActivity} for an example.
+   * <p>See {@code com.tudutu.plugins.flutterbettercamera.MainActivity} for an example.
    */
   public CameraPlugin() {}
 

--- a/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/CameraPlugin.java
+++ b/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/CameraPlugin.java
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-package io.flutter.plugins.camera;
+package com.tudutu.plugins.flutterBetterCamera;
 
 import android.app.Activity;
 import android.os.Build;
@@ -13,14 +13,14 @@ import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
-import io.flutter.plugins.camera.CameraPermissions.PermissionsRegistry;
+import com.tudutu.plugins.flutterBetterCamera.CameraPermissions.PermissionsRegistry;
 import io.flutter.view.TextureRegistry;
 
 /**
  * Platform implementation of the camera_plugin.
  *
  * <p>Instantiate this in an add to app scenario to gracefully handle activity and context changes.
- * See {@code io.flutter.plugins.camera.MainActivity} for an example.
+ * See {@code com.tudutu.plugins.flutterBetterCamera.MainActivity} for an example.
  *
  * <p>Call {@link #registerWith(Registrar)} to register an implementation of this that uses the
  * stable {@code io.flutter.plugin.common} package.
@@ -34,7 +34,7 @@ public final class CameraPlugin implements FlutterPlugin, ActivityAware {
   /**
    * Initialize this within the {@code #configureFlutterEngine} of a Flutter activity or fragment.
    *
-   * <p>See {@code io.flutter.plugins.camera.MainActivity} for an example.
+   * <p>See {@code com.tudutu.plugins.flutterBetterCamera.MainActivity} for an example.
    */
   public CameraPlugin() {}
 

--- a/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/CameraUtils.java
+++ b/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/CameraUtils.java
@@ -1,4 +1,4 @@
-package com.tudutu.plugins.flutterBetterCamera;
+package com.tudutu.plugins.flutterbettercamera;
 
 import android.app.Activity;
 import android.content.Context;
@@ -10,7 +10,7 @@ import android.hardware.camera2.CameraMetadata;
 import android.hardware.camera2.params.StreamConfigurationMap;
 import android.media.CamcorderProfile;
 import android.util.Size;
-import com.tudutu.plugins.flutterBetterCamera.Camera.ResolutionPreset;
+import com.tudutu.plugins.flutterbettercamera.Camera.ResolutionPreset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/CameraUtils.java
+++ b/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/CameraUtils.java
@@ -1,4 +1,4 @@
-package io.flutter.plugins.camera;
+package com.tudutu.plugins.flutterBetterCamera;
 
 import android.app.Activity;
 import android.content.Context;
@@ -10,7 +10,7 @@ import android.hardware.camera2.CameraMetadata;
 import android.hardware.camera2.params.StreamConfigurationMap;
 import android.media.CamcorderProfile;
 import android.util.Size;
-import io.flutter.plugins.camera.Camera.ResolutionPreset;
+import com.tudutu.plugins.flutterBetterCamera.Camera.ResolutionPreset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/Constants.java
+++ b/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/Constants.java
@@ -1,4 +1,4 @@
-package io.flutter.plugins.camera;
+package com.tudutu.plugins.flutterBetterCamera;
 
 public interface Constants {
 

--- a/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/Constants.java
+++ b/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/Constants.java
@@ -1,4 +1,4 @@
-package com.tudutu.plugins.flutterBetterCamera;
+package com.tudutu.plugins.flutterbettercamera;
 
 public interface Constants {
 

--- a/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/DartMessenger.java
+++ b/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/DartMessenger.java
@@ -1,4 +1,4 @@
-package com.tudutu.plugins.flutterBetterCamera;
+package com.tudutu.plugins.flutterbettercamera;
 
 import android.text.TextUtils;
 import androidx.annotation.Nullable;

--- a/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/DartMessenger.java
+++ b/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/DartMessenger.java
@@ -1,4 +1,4 @@
-package io.flutter.plugins.camera;
+package com.tudutu.plugins.flutterBetterCamera;
 
 import android.text.TextUtils;
 import androidx.annotation.Nullable;
@@ -16,7 +16,7 @@ class DartMessenger {
   }
 
   DartMessenger(BinaryMessenger messenger, long eventChannelId) {
-    new EventChannel(messenger, "flutter.io/cameraPlugin/cameraEvents" + eventChannelId)
+    new EventChannel(messenger, "tudutu.com/flutterBetterCameraPlugin/cameraEvents" + eventChannelId)
         .setStreamHandler(
             new EventChannel.StreamHandler() {
               @Override

--- a/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/MethodCallHandlerImpl.java
@@ -1,4 +1,4 @@
-package com.tudutu.plugins.flutterBetterCamera;
+package com.tudutu.plugins.flutterbettercamera;
 
 import android.app.Activity;
 import android.content.pm.PackageManager;
@@ -12,7 +12,7 @@ import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.Result;
-import com.tudutu.plugins.flutterBetterCamera.CameraPermissions.PermissionsRegistry;
+import com.tudutu.plugins.flutterbettercamera.CameraPermissions.PermissionsRegistry;
 import io.flutter.view.TextureRegistry;
 
 final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {

--- a/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/tudutu/plugins/flutterBetterCamera/MethodCallHandlerImpl.java
@@ -1,4 +1,4 @@
-package io.flutter.plugins.camera;
+package com.tudutu.plugins.flutterBetterCamera;
 
 import android.app.Activity;
 import android.content.pm.PackageManager;
@@ -12,7 +12,7 @@ import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugins.camera.CameraPermissions.PermissionsRegistry;
+import com.tudutu.plugins.flutterBetterCamera.CameraPermissions.PermissionsRegistry;
 import io.flutter.view.TextureRegistry;
 
 final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
@@ -37,8 +37,8 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
     this.permissionsRegistry = permissionsAdder;
     this.textureRegistry = textureRegistry;
 
-    methodChannel = new MethodChannel(messenger, "plugins.flutter.io/camera");
-    imageStreamChannel = new EventChannel(messenger, "plugins.flutter.io/camera/imageStream");
+    methodChannel = new MethodChannel(messenger, "plugins.tudutu.com/flutterBetterCamera");
+    imageStreamChannel = new EventChannel(messenger, "plugins.tudutu.com/flutterBetterCamera/imageStream");
     methodChannel.setMethodCallHandler(this);
   }
 

--- a/android/src/test/java/io/flutter/plugins/camera/DartMessengerTest.java
+++ b/android/src/test/java/io/flutter/plugins/camera/DartMessengerTest.java
@@ -1,4 +1,4 @@
-package com.tudutu.plugins.flutterBetterCamera;
+package com.tudutu.plugins.flutterbettercamera;
 
 import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertEquals;

--- a/android/src/test/java/io/flutter/plugins/camera/DartMessengerTest.java
+++ b/android/src/test/java/io/flutter/plugins/camera/DartMessengerTest.java
@@ -1,4 +1,4 @@
-package io.flutter.plugins.camera;
+package com.tudutu.plugins.flutterBetterCamera;
 
 import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertEquals;

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -32,7 +32,7 @@ android {
     }
 
     defaultConfig {
-        applicationId "io.flutter.plugins.cameraexample"
+        applicationId "com.tudutu.plugins.flutterBetterCameraexample"
         minSdkVersion 21
         targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()

--- a/example/android/app/src/androidTestDebug/java/io/flutter/plugins/cameraexample/EmbeddingV1ActivityTest.java
+++ b/example/android/app/src/androidTestDebug/java/io/flutter/plugins/cameraexample/EmbeddingV1ActivityTest.java
@@ -1,4 +1,4 @@
-package io.flutter.plugins.cameraexample;
+package com.tudutu.plugins.flutterBetterCameraexample;
 
 import androidx.test.rule.ActivityTestRule;
 import dev.flutter.plugins.e2e.FlutterRunner;

--- a/example/android/app/src/androidTestDebug/java/io/flutter/plugins/cameraexample/MainActivityTest.java
+++ b/example/android/app/src/androidTestDebug/java/io/flutter/plugins/cameraexample/MainActivityTest.java
@@ -1,4 +1,4 @@
-package io.flutter.plugins.cameraexample;
+package com.tudutu.plugins.flutterBetterCameraexample;
 
 import androidx.test.rule.ActivityTestRule;
 import dev.flutter.plugins.e2e.FlutterRunner;

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="io.flutter.plugins.cameraexample">
+  package="com.tudutu.plugins.flutterBetterCameraexample">
 
   <application
     android:icon="@mipmap/ic_launcher"

--- a/example/android/app/src/main/java/io/flutter/plugins/cameraexample/EmbeddingV1Activity.java
+++ b/example/android/app/src/main/java/io/flutter/plugins/cameraexample/EmbeddingV1Activity.java
@@ -1,4 +1,4 @@
-package io.flutter.plugins.cameraexample;
+package com.tudutu.plugins.flutterBetterCameraexample;
 
 import android.os.Bundle;
 import io.flutter.app.FlutterActivity;

--- a/example/android/app/src/main/java/io/flutter/plugins/cameraexample/MainActivity.java
+++ b/example/android/app/src/main/java/io/flutter/plugins/cameraexample/MainActivity.java
@@ -4,7 +4,7 @@ import androidx.annotation.NonNull;
 import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.plugins.shim.ShimPluginRegistry;
-import com.tudutu.plugins.flutterBetterCamera.CameraPlugin;
+import com.tudutu.plugins.flutterbettercamera.CameraPlugin;
 import io.flutter.plugins.pathprovider.PathProviderPlugin;
 import io.flutter.plugins.videoplayer.VideoPlayerPlugin;
 

--- a/example/android/app/src/main/java/io/flutter/plugins/cameraexample/MainActivity.java
+++ b/example/android/app/src/main/java/io/flutter/plugins/cameraexample/MainActivity.java
@@ -1,10 +1,10 @@
-package io.flutter.plugins.cameraexample;
+package com.tudutu.plugins.flutterBetterCameraexample;
 
 import androidx.annotation.NonNull;
 import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.plugins.shim.ShimPluginRegistry;
-import io.flutter.plugins.camera.CameraPlugin;
+import com.tudutu.plugins.flutterBetterCamera.CameraPlugin;
 import io.flutter.plugins.pathprovider.PathProviderPlugin;
 import io.flutter.plugins.videoplayer.VideoPlayerPlugin;
 

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -439,7 +439,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.cameraExampleTest;
+				PRODUCT_BUNDLE_IDENTIFIER = com.tudutu.plugins.flutterBetterCameraExampleTest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -461,7 +461,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.cameraExampleTest;
+				PRODUCT_BUNDLE_IDENTIFIER = com.tudutu.plugins.flutterBetterCameraExampleTest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/example/test_driver/camera_e2e_test.dart
+++ b/example/test_driver/camera_e2e_test.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 
 import 'package:flutter_driver/flutter_driver.dart';
 
-const String _examplePackage = 'io.flutter.plugins.cameraexample';
+const String _examplePackage = 'com.tudutu.plugins.flutterBetterCameraexample';
 
 Future<void> main() async {
   if (!(Platform.isLinux || Platform.isMacOS)) {

--- a/ios/Classes/FlutterBetterCameraPlugin.h
+++ b/ios/Classes/FlutterBetterCameraPlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface CameraPlugin : NSObject <FlutterPlugin>
+@interface FlutterBetterCameraPlugin : NSObject <FlutterBetterCameraPlugin>
 @end

--- a/ios/Classes/FlutterBetterCameraPlugin.h
+++ b/ios/Classes/FlutterBetterCameraPlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FlutterBetterCameraPlugin : NSObject <FlutterBetterCameraPlugin>
+@interface FlutterBetterCameraPlugin : NSObject <FlutterPlugin>
 @end

--- a/ios/Classes/FlutterBetterCameraPlugin.m
+++ b/ios/Classes/FlutterBetterCameraPlugin.m
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#import "CameraPlugin.h"
+#import "FlutterBetterCameraPlugin.h"
 #import <AVFoundation/AVFoundation.h>
 #import <Accelerate/Accelerate.h>
 #import <CoreMotion/CoreMotion.h>
@@ -675,7 +675,7 @@ FourCharCode const videoFormat = kCVPixelFormatType_32BGRA;
 - (void)startImageStreamWithMessenger:(NSObject<FlutterBinaryMessenger> *)messenger {
   if (!_isStreamingImages) {
     FlutterEventChannel *eventChannel =
-        [FlutterEventChannel eventChannelWithName:@"plugins.flutter.io/camera/imageStream"
+        [FlutterEventChannel eventChannelWithName:@"plugins.tudutu.com/flutterBetterCamera/imageStream"
                                   binaryMessenger:messenger];
 
     _imageStreamHandler = [[FLTImageStreamHandler alloc] init];
@@ -863,20 +863,20 @@ FourCharCode const videoFormat = kCVPixelFormatType_32BGRA;
 }
 @end
 
-@interface CameraPlugin ()
+@interface FlutterBetterCameraPlugin ()
 @property(readonly, nonatomic) NSObject<FlutterTextureRegistry> *registry;
 @property(readonly, nonatomic) NSObject<FlutterBinaryMessenger> *messenger;
 @property(readonly, nonatomic) FLTCam *camera;
 @end
 
-@implementation CameraPlugin {
+@implementation FlutterBetterCameraPlugin {
   dispatch_queue_t _dispatchQueue;
 }
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
   FlutterMethodChannel *channel =
-      [FlutterMethodChannel methodChannelWithName:@"plugins.flutter.io/camera"
+      [FlutterMethodChannel methodChannelWithName:@"plugins.tudutu.com/flutterBetterCamera"
                                   binaryMessenger:[registrar messenger]];
-  CameraPlugin *instance = [[CameraPlugin alloc] initWithRegistry:[registrar textures]
+  FlutterBetterCameraPlugin *instance = [[FlutterBetterCameraPlugin alloc] initWithRegistry:[registrar textures]
                                                         messenger:[registrar messenger]];
   [registrar addMethodCallDelegate:instance channel:channel];
 }
@@ -892,7 +892,7 @@ FourCharCode const videoFormat = kCVPixelFormatType_32BGRA;
 
 - (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
   if (_dispatchQueue == nil) {
-    _dispatchQueue = dispatch_queue_create("io.flutter.camera.dispatchqueue", NULL);
+    _dispatchQueue = dispatch_queue_create("com.tudutu.flutterBetterCamera.dispatchqueue", NULL);
   }
 	
   // Invoke the plugin on another dispatch queue to avoid blocking the UI.
@@ -960,7 +960,7 @@ FourCharCode const videoFormat = kCVPixelFormatType_32BGRA;
       };
       FlutterEventChannel *eventChannel = [FlutterEventChannel
           eventChannelWithName:[NSString
-                                   stringWithFormat:@"flutter.io/cameraPlugin/cameraEvents%lld",
+                                   stringWithFormat:@"tudutu.com/flutterBetterCameraPlugin/cameraEvents%lld",
                                                     textureId]
                binaryMessenger:_messenger];
       [eventChannel setStreamHandler:cam];

--- a/ios/Tests/FlutterBetterCameraPluginTests.m
+++ b/ios/Tests/FlutterBetterCameraPluginTests.m
@@ -1,10 +1,10 @@
-@import camera;
+@import flutterBetterCamera;
 @import XCTest;
 
-@interface CameraPluginTests : XCTestCase
+@interface FlutterBetterCameraPluginTests : XCTestCase
 @end
 
-@implementation CameraPluginTests
+@implementation FlutterBetterCameraPluginTests
 
 - (void)testModuleImport {
   // This test will fail to compile if the module cannot be imported.

--- a/lib/camera.dart
+++ b/lib/camera.dart
@@ -11,7 +11,8 @@ import 'package:flutter/widgets.dart';
 
 part 'camera_image.dart';
 
-final MethodChannel _channel = const MethodChannel('plugins.flutter.io/camera');
+final MethodChannel _channel =
+    const MethodChannel('plugins.tudutu.com/flutterBetterCamera');
 
 enum CameraLensDirection { front, back, external }
 
@@ -179,14 +180,13 @@ class CameraValue {
 
   const CameraValue.uninitialized()
       : this(
-      isInitialized: false,
-      isRecordingVideo: false,
-      isTakingPicture: false,
-      isStreamingImages: false,
-      isRecordingPaused: false,
-      autoFocusEnabled: true,
-      flashMode: FlashMode.off
-  );
+            isInitialized: false,
+            isRecordingVideo: false,
+            isTakingPicture: false,
+            isStreamingImages: false,
+            isRecordingPaused: false,
+            autoFocusEnabled: true,
+            flashMode: FlashMode.off);
 
   /// True after [CameraController.initialize] has completed successfully.
   final bool isInitialized;
@@ -199,7 +199,6 @@ class CameraValue {
 
   /// FlashMode
   final FlashMode flashMode;
-
 
   /// True when the camera is recording (not the same as previewing).
   final bool isRecordingVideo;
@@ -226,17 +225,16 @@ class CameraValue {
 
   bool get hasError => errorDescription != null;
 
-  CameraValue copyWith({
-    bool isInitialized,
-    bool isRecordingVideo,
-    bool isTakingPicture,
-    bool isStreamingImages,
-    String errorDescription,
-    Size previewSize,
-    bool isRecordingPaused,
-    bool autoFocusEnabled,
-    FlashMode flashMode
-  }) {
+  CameraValue copyWith(
+      {bool isInitialized,
+      bool isRecordingVideo,
+      bool isTakingPicture,
+      bool isStreamingImages,
+      String errorDescription,
+      Size previewSize,
+      bool isRecordingPaused,
+      bool autoFocusEnabled,
+      FlashMode flashMode}) {
     return CameraValue(
       isInitialized: isInitialized ?? this.isInitialized,
       errorDescription: errorDescription,
@@ -270,13 +268,12 @@ class CameraValue {
 ///
 /// To show the camera preview on the screen use a [CameraPreview] widget.
 class CameraController extends ValueNotifier<CameraValue> {
-  CameraController(this.description,
-      this.resolutionPreset, {
-        this.enableAudio = true,
-        this.autoFocusEnabled = true,
-        this.flashMode = FlashMode.off,
-        this.enableAutoExposure = true
-      }) : super(const CameraValue.uninitialized());
+  CameraController(this.description, this.resolutionPreset,
+      {this.enableAudio = true,
+      this.autoFocusEnabled = true,
+      this.flashMode = FlashMode.off,
+      this.enableAutoExposure = true})
+      : super(const CameraValue.uninitialized());
 
   final CameraDescription description;
   final ResolutionPreset resolutionPreset;
@@ -305,7 +302,7 @@ class CameraController extends ValueNotifier<CameraValue> {
     try {
       _creatingCompleter = Completer<void>();
       final Map<String, dynamic> reply =
-      await _channel.invokeMapMethod<String, dynamic>(
+          await _channel.invokeMapMethod<String, dynamic>(
         'initialize',
         <String, dynamic>{
           'cameraName': description.name,
@@ -327,11 +324,11 @@ class CameraController extends ValueNotifier<CameraValue> {
     } on PlatformException catch (e) {
       throw CameraException(e.code, e.message);
     }
-    
-    _eventSubscription =
-        EventChannel('flutter.io/cameraPlugin/cameraEvents$_textureId')
-            .receiveBroadcastStream()
-            .listen(_listener);
+
+    _eventSubscription = EventChannel(
+            'tudutu.com/flutterBetterCameraPlugin/cameraEvents$_textureId')
+        .receiveBroadcastStream()
+        .listen(_listener);
     _creatingCompleter.complete();
     return _creatingCompleter.future;
   }
@@ -369,7 +366,6 @@ class CameraController extends ValueNotifier<CameraValue> {
         break;
     }
   }
-
 
   /// Captures an image and saves it to [path].
   ///
@@ -446,13 +442,13 @@ class CameraController extends ValueNotifier<CameraValue> {
       throw CameraException(e.code, e.message);
     }
     const EventChannel cameraEventChannel =
-    EventChannel('plugins.flutter.io/camera/imageStream');
+        EventChannel('plugins.tudutu.com/flutterBetterCamera/imageStream');
     _imageStreamSubscription =
         cameraEventChannel.receiveBroadcastStream().listen(
-              (dynamic imageData) {
-            onAvailable(CameraImage._fromPlatformData(imageData));
-          },
-        );
+      (dynamic imageData) {
+        onAvailable(CameraImage._fromPlatformData(imageData));
+      },
+    );
   }
 
   /// Stop streaming images from platform camera.
@@ -693,6 +689,4 @@ class CameraController extends ValueNotifier<CameraValue> {
       await _eventSubscription?.cancel();
     }
   }
-
-
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: flutter_better_camera
+name: camera
 description: Flutter plugin for controlling the camera on Android and IOS, supports camera feed, capturing images, capturing videos, streaming image buffers and has support for all the essential features the camera APIs allow (flash, AE and more)
 version: 0.6.1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: camera
+name: flutter_better_camera
 description: Flutter plugin for controlling the camera on Android and IOS, supports camera feed, capturing images, capturing videos, streaming image buffers and has support for all the essential features the camera APIs allow (flash, AE and more)
 version: 0.6.1
 
@@ -13,15 +13,15 @@ dev_dependencies:
     sdk: flutter
   flutter_driver:
     sdk: flutter
-homepage: https://github.com/Lightsnap/flutter-better-camera/
+homepage: https://github.com/tudutu/flutter-better-camera/
 flutter:
   plugin:
     platforms:
       android:
-        package: io.flutter.plugins.camera
-        pluginClass: CameraPlugin
+        package: com.tudutu.plugins.flutterBetterCamera
+        pluginClass: FlutterBetterCameraPlugin
       ios:
-        pluginClass: CameraPlugin
+        pluginClass: FlutterBetterCameraPlugin
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ flutter:
     platforms:
       android:
         package: com.tudutu.plugins.flutterBetterCamera
-        pluginClass: FlutterBetterCameraPlugin
+        pluginClass: CameraPlugin
       ios:
         pluginClass: FlutterBetterCameraPlugin
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ flutter:
   plugin:
     platforms:
       android:
-        package: com.tudutu.plugins.flutterBetterCamera
+        package: com.tudutu.plugins.flutterbettercamera
         pluginClass: CameraPlugin
       ios:
         pluginClass: FlutterBetterCameraPlugin


### PR DESCRIPTION
When trying to use this plugin with our projects, they failed to build because the name of the plugin was the same as the original camera plugin and other plugins were referencing that. To avoid duplication of included plugins, I had to rename the plugin to match the project's name and thought maybe someone else would like to do the same.

Great plugin btw! Thanks for all your great work.