### PR TITLE
Add missing zoom setting.

### DIFF
--- a/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -564,6 +564,8 @@ public class Camera {
 
       captureBuilder.set(CaptureRequest.JPEG_ORIENTATION, getMediaOrientation());
 
+      // Set zoom level
+      captureBuilder.set(CaptureRequest.SCALER_CROP_REGION, mPreviewRequestBuilder.get(CaptureRequest.SCALER_CROP_REGION));
 
       mCaptureSession.capture(
           captureBuilder.build(),


### PR DESCRIPTION
The zoom worked on the preview but not when taking a photo. The setting for the preview hadn't been copied over into the takePicture method.